### PR TITLE
Implemented helper accesing Copernicus Open Access Hub through OData and SORL APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ option(WITH_CEPH "Include Ceph direct IO support" ON)
 option(WITH_S3 "Include S3 direct IO support" ON)
 option(WITH_SWIFT "Include Swift direct IO support" ON)
 option(WITH_GLUSTERFS "Include GlusterFS direct IO support" ON)
+option(WITH_ODATA "Include Copernicus Data Hub support" ON)
 option(BUILD_PROXY_IO "Build Proxy IO helper." ON)
 
 # CMake config
@@ -140,6 +141,14 @@ else(WITH_GLUSTERFS)
     add_definitions(-DWITH_GLUSTERFS=0)
 endif(WITH_GLUSTERFS)
 
+# Copernicus Data hub support
+if(WITH_ODATA)
+    find_package(odata REQUIRED)
+    set(ODATA_LIBRARIES ${ODATA_LIBRARIES})
+else(WITH_ODATA)
+    add_definitions(-DWITH_ODATA=0)
+endif(WITH_ODATA)
+
 # Setup compile flags
 set(PLATFORM_EXTRA_LIBS
     ${CMAKE_THREAD_LIBS_INIT}
@@ -211,6 +220,10 @@ endif(WITH_SWIFT)
 if(WITH_GLUSTERFS)
     list(APPEND HELPERS_LIBRARIES ${GLUSTERFSAPI_LIBRARIES})
 endif(WITH_GLUSTERFS)
+
+if(WITH_ODATA)
+    list(APPEND HELPERS_LIBRARIES ${ODATA_LIBRARIES})
+endif(WITH_ODATA)
 
 add_library(helpersShared SHARED ${HELPERS_SOURCES})
 target_link_libraries(helpersShared PUBLIC ${HELPERS_LIBRARIES})

--- a/include/helpers/storageHelperCreator.h
+++ b/include/helpers/storageHelperCreator.h
@@ -48,6 +48,10 @@ constexpr auto SWIFT_HELPER_NAME = "swift";
 constexpr auto GLUSTERFS_HELPER_NAME = "glusterfs";
 #endif
 
+#if WITH_ODATA
+constexpr auto ODATA_HELPER_NAME = "odata";
+#endif
+
 namespace buffering {
 
 struct BufferLimits {
@@ -97,6 +101,9 @@ public:
 #if WITH_GLUSTERFS
         asio::io_service &glusterfsService,
 #endif
+#if WITH_ODATA
+        asio::io_service &odataService,
+#endif
         communication::Communicator &m_communicator,
         std::size_t bufferSchedulerWorkers = 1,
         buffering::BufferLimits bufferLimits = buffering::BufferLimits{});
@@ -114,6 +121,9 @@ public:
 #endif
 #if WITH_GLUSTERFS
         asio::io_service &glusterfsService,
+#endif
+#if WITH_ODATA
+        asio::io_service &odataService,
 #endif
         std::size_t bufferSchedulerWorkers = 1,
         buffering::BufferLimits bufferLimits = buffering::BufferLimits{});
@@ -147,7 +157,10 @@ private:
 #if WITH_GLUSTERFS
     asio::io_service &m_glusterfsService;
 #endif
-    std::unique_ptr<Scheduler> m_scheduler;
+#if WITH_ODATA
+    asio::io_service &m_odataService,
+#endif
+        std::unique_ptr<Scheduler> m_scheduler;
     buffering::BufferLimits m_bufferLimits;
 
 #ifdef BUILD_PROXY_IO

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,10 @@ if(NOT WITH_GLUSTERFS)
     list(REMOVE_ITEM HELPER_SOURCES  ${CMAKE_CURRENT_SOURCE_DIR}/glusterfsHelper.cc)
 endif(NOT WITH_GLUSTERFS)
 
+if(NOT WITH_ODATA)
+    list(REMOVE_ITEM HELPER_SOURCES  ${CMAKE_CURRENT_SOURCE_DIR}/odataHelper.cc)
+endif(NOT WITH_ODATA)
+
 add_library(helpers OBJECT ${HELPER_SOURCES})
 add_dependencies(helpers clproto)
 target_include_directories(helpers SYSTEM PRIVATE

--- a/src/odataHelper.cc
+++ b/src/odataHelper.cc
@@ -1,0 +1,197 @@
+/*
+ * odataHelper.cpp
+ *
+ *  Created on: 5. 2. 2018
+ *      Author: Jakub Valenta
+ */
+
+#include "odataHelper.h"
+
+#include "asioExecutor.h"
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem/path.hpp>
+#include <folly/FBString.h>
+#include <folly/io/IOBufQueue.h>
+#include <memory>
+#include <odata/DataHub.h>
+#include <odata/DataHubConnection.h>
+#include <odata/FileSystemNode.h>
+#include <unistd.h>
+
+namespace one {
+namespace helpers {
+
+namespace {
+std::vector<std::string> parseMissions(const std::string &missions)
+{
+    std::vector<std::string> splited;
+    boost::split(splited, missions, [](char c) { return c == ','; });
+    return splited;
+}
+}
+
+ODataFile::ODataFile(folly::fbstring fileId,
+    std::shared_ptr<folly::Executor> executor,
+    std::shared_ptr<OData::DataHub> data_hub)
+    : FileHandle(std::move(fileId))
+    , m_executor(std::move(executor))
+    , m_data_hub(std::move(data_hub))
+    , m_timeout(ASYNC_OPS_TIMEOUT)
+{
+}
+
+folly::Future<folly::IOBufQueue> ODataFile::read(
+    const off_t offset, const std::size_t size)
+{
+    return folly::via(m_executor.get(), [=]() {
+        folly::IOBufQueue buffer;
+        const auto content = m_data_hub->getFile(
+            boost::filesystem::path(m_fileId.c_str()), offset, size);
+        buffer.append(content.data(), content.size());
+        return folly::makeFuture(std::move(buffer));
+    });
+}
+
+folly::Future<std::size_t> ODataFile::write(
+    const off_t offset, folly::IOBufQueue buf)
+{
+    return folly::via(m_executor.get(), []() {
+        return folly::makeFuture<std::size_t>(std::system_error{
+            std::make_error_code(std::errc::function_not_supported)});
+    });
+}
+
+const Timeout &ODataFile::timeout() { return m_timeout; }
+
+ODataHelper::ODataHelper(std::shared_ptr<folly::Executor> executor,
+    const folly::fbstring &data_hub_url, const folly::fbstring &username,
+    const folly::fbstring &password, const folly::fbstring &missions,
+    const folly::fbstring &db_path, const folly::fbstring &tmp_path,
+    const std::uint32_t tmp_size)
+    : m_executor(std::move(executor))
+    , m_timeout(ASYNC_OPS_TIMEOUT)
+    , m_connection(
+          std::make_shared<OData::DataHubConnection>(data_hub_url.toStdString(),
+              username.toStdString(), password.toStdString()))
+    , m_data_hub(std::make_shared<OData::DataHub>(*m_connection,
+          parseMissions(missions.toStdString()), db_path.toStdString(),
+          tmp_path.toStdString(), tmp_size))
+{
+}
+
+folly::Future<struct stat> ODataHelper::getattr(const folly::fbstring &fileId)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<struct stat>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        struct stat attr;
+        std::memset(&attr, 0, sizeof(attr));
+        attr.st_uid = getuid();
+        attr.st_gid = getgid();
+        if (file->isDirectory()) {
+            attr.st_mode = 0555;
+        }
+        else {
+            attr.st_mode = 0444;
+        }
+        attr.st_size = file->getSize();
+
+        return folly::makeFuture<struct stat>(std::move(attr));
+    });
+}
+
+folly::Future<folly::Unit> ODataHelper::access(
+    const folly::fbstring &fileId, const int mask)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<folly::Unit>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        return folly::makeFuture();
+    });
+}
+
+folly::Future<folly::fbvector<folly::fbstring>> ODataHelper::readdir(
+    const folly::fbstring &fileId, const off_t offset, const std::size_t count)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto directory = m_data_hub->getFile(fileId.toStdString());
+        if (directory == nullptr) {
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::system_error{std::make_error_code(
+                    std::errc::no_such_file_or_directory)});
+        }
+        else if (directory->isDirectory()) {
+            auto dir_content = directory->readDir();
+            dir_content.push_back(".");
+            dir_content.push_back("..");
+            folly::fbvector<folly::fbstring> dir;
+            for (auto i = static_cast<std::size_t>(offset);
+                 i < dir_content.size() && i < offset + count; ++i) {
+                dir.push_back(folly::fbstring(dir_content[i]));
+            }
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::move(dir));
+        }
+        else {
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::system_error{
+                    std::make_error_code(std::errc::not_a_directory)});
+        }
+    });
+}
+
+folly::Future<FileHandlePtr> ODataHelper::open(
+    const folly::fbstring &fileId, const int flags, const Params &openParams)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<FileHandlePtr>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        else if (file->isDirectory()) {
+            return folly::makeFuture<FileHandlePtr>(std::system_error{
+                std::make_error_code(std::errc::is_a_directory)});
+        }
+        return folly::makeFuture<FileHandlePtr>(
+            std::make_shared<ODataFile>(fileId, m_executor, m_data_hub));
+    });
+}
+
+folly::Future<folly::fbstring> ODataHelper::getxattr(
+    const folly::fbstring &uuid, const folly::fbstring &name)
+{
+    return folly::via(m_executor.get(),
+        []() { return makeFuturePosixException<folly::fbstring>(ENOTSUP); });
+}
+
+const Timeout &ODataHelper::timeout() { return m_timeout; }
+
+ODataHelperFactory::ODataHelperFactory(asio::io_service &service)
+    : m_service(service)
+{
+}
+
+std::shared_ptr<StorageHelper> ODataHelperFactory::createStorageHelper(
+    const Params &parameters)
+{
+    const auto &url = getParam(parameters, "datahubUrl");
+    const auto &username = getParam(parameters, "username");
+    const auto &password = getParam(parameters, "password");
+    const auto &missions = getParam(parameters, "missions");
+    const auto &db_path = getParam(parameters, "databasePath");
+    const auto &tmp_path = getParam(parameters, "tmpPath");
+    const auto &tmp_size = getParam(parameters, "tmpSize");
+    return std::make_shared<ODataHelper>(
+        std::make_shared<AsioExecutor>(m_service), url, username, password,
+        missions, db_path, tmp_path, std::stoi(tmp_size.toStdString()));
+}
+
+} /* namespace helpers */
+} /* namespace one */

--- a/src/odataHelper.h
+++ b/src/odataHelper.h
@@ -1,0 +1,83 @@
+/*
+ * odataHelper.h
+ *
+ *  Created on: 5. 2. 2018
+ *      Author: Jakub Valenta
+ */
+
+#ifndef HELPERS_ODATAHELPER_H_
+#define HELPERS_ODATAHELPER_H_
+
+#include "helpers/storageHelper.h"
+
+namespace OData {
+
+class Connection;
+class DataHub;
+class FileSystemNode;
+}
+
+namespace one {
+namespace helpers {
+
+class ODataFile : public FileHandle {
+public:
+    ODataFile(folly::fbstring fileId, std::shared_ptr<folly::Executor> executor,
+        std::shared_ptr<OData::DataHub> data_hub);
+    virtual ~ODataFile() = default;
+    folly::Future<folly::IOBufQueue> read(
+        const off_t offset, const std::size_t size) override;
+
+    folly::Future<std::size_t> write(
+        const off_t offset, folly::IOBufQueue buf) override;
+    const Timeout &timeout() override;
+
+private:
+    std::shared_ptr<folly::Executor> m_executor;
+    std::shared_ptr<OData::DataHub> m_data_hub;
+    Timeout m_timeout;
+};
+
+class ODataHelper : public StorageHelper {
+public:
+    explicit ODataHelper(std::shared_ptr<folly::Executor> executor,
+        const folly::fbstring &data_hub_url, const folly::fbstring &username,
+        const folly::fbstring &password, const folly::fbstring &missions,
+        const folly::fbstring &db_path, const folly::fbstring &tmp_path,
+        const std::uint32_t tmp_size);
+    virtual ~ODataHelper() = default;
+    folly::Future<struct stat> getattr(const folly::fbstring &fileId) override;
+    folly::Future<folly::Unit> access(
+        const folly::fbstring &fileId, const int mask) override;
+    folly::Future<folly::fbvector<folly::fbstring>> readdir(
+        const folly::fbstring &fileId, const off_t offset,
+        const std::size_t count) override;
+    folly::Future<FileHandlePtr> open(const folly::fbstring &fileId,
+        const int flags, const Params &openParams) override;
+    folly::Future<folly::fbstring> getxattr(
+        const folly::fbstring &uuid, const folly::fbstring &name) override;
+
+    const Timeout &timeout() override;
+
+private:
+    std::shared_ptr<folly::Executor> m_executor;
+    Timeout m_timeout;
+    std::shared_ptr<OData::Connection> m_connection;
+    std::shared_ptr<OData::DataHub> m_data_hub;
+};
+
+class ODataHelperFactory : public StorageHelperFactory {
+public:
+    ODataHelperFactory(asio::io_service &service);
+    virtual ~ODataHelperFactory() = default;
+    std::shared_ptr<StorageHelper> createStorageHelper(
+        const Params &parameters) override;
+
+private:
+    asio::io_service &m_service;
+};
+
+} /* namespace helpers */
+} /* namespace one */
+
+#endif /* HELPERS_ODATAHELPER_H_ */

--- a/src/storageHelperCreator.cc
+++ b/src/storageHelperCreator.cc
@@ -29,6 +29,9 @@
 #include "glusterfsHelper.h"
 #endif
 
+#if WITH_ODATA
+#include "odataHelper.h"
+#endif
 namespace one {
 namespace helpers {
 
@@ -47,6 +50,9 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_GLUSTERFS
     asio::io_service &glusterfsService,
+#endif
+#if WITH_ODATA
+    asio::io_service &odataService,
 #endif
     communication::Communicator &communicator,
     std::size_t bufferSchedulerWorkers, buffering::BufferLimits bufferLimits)
@@ -67,6 +73,10 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_GLUSTERFS
     m_glusterfsService{glusterfsService}
+    ,
+#endif
+#if WITH_ODATA
+    m_odataService(odataService)
     ,
 #endif
     m_scheduler{std::make_unique<Scheduler>(bufferSchedulerWorkers)}
@@ -90,6 +100,9 @@ StorageHelperCreator::StorageHelperCreator(
 #if WITH_GLUSTERFS
     asio::io_service &glusterfsService,
 #endif
+#if WITH_ODATA
+    asio::io_service &odataService,
+#endif
     std::size_t bufferSchedulerWorkers, buffering::BufferLimits bufferLimits)
     :
 #if WITH_CEPH
@@ -108,6 +121,10 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_GLUSTERFS
     m_glusterfsService{glusterfsService}
+    ,
+#endif
+#if WITH_ODATA
+    m_odataService(odataService)
     ,
 #endif
     m_scheduler{std::make_unique<Scheduler>(bufferSchedulerWorkers)}
@@ -152,6 +169,10 @@ std::shared_ptr<StorageHelper> StorageHelperCreator::getStorageHelper(
     if (name == GLUSTERFS_HELPER_NAME)
         helper = GlusterFSHelperFactory{m_glusterfsService}.createStorageHelper(
             args);
+#endif
+#if WITH_ODATA
+    if (name == ODATA_HELPER_NAME)
+        helper = ODataHelperFactory{m_odataService}.createStorageHelper(args);
 #endif
 
     if (!helper)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -59,6 +59,10 @@ if(NOT WITH_GLUSTERFS)
     list(REMOVE_ITEM TEST_DIRS  glusterfs_helper_test)
 endif(NOT WITH_GLUSTERFS)
 
+if(NOT WITH_ODATA)
+    list(REMOVE_ITEM TEST_DIRS  odata_helper_test)
+endif(NOT WITH_ODATA)
+
 foreach(TEST_DIR ${TEST_DIRS})
     string(REGEX REPLACE "(.*)_test" "\\1" TEST_NAME ${TEST_DIR})
     file(COPY ${TEST_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/integration/odata_helper_test/odataHelperProxy.cc
+++ b/test/integration/odata_helper_test/odataHelperProxy.cc
@@ -1,0 +1,267 @@
+/*
+ * odataHelperProxy.cc
+ *
+ *  Created on: 11. 4. 2018
+ *      Author: jakub
+ */
+#include "odataHelper.h"
+
+#include "asioExecutor.h"
+#include <asio/buffer.hpp>
+#include <asio/executor_work.hpp>
+#include <asio/io_service.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/python.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/raw_function.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+using namespace boost::python;
+using namespace one::helpers;
+
+class ReleaseGIL {
+public:
+    ReleaseGIL()
+        : threadState{PyEval_SaveThread(), PyEval_RestoreThread}
+    {
+    }
+
+private:
+    std::unique_ptr<PyThreadState, decltype(&PyEval_RestoreThread)> threadState;
+};
+
+constexpr int ODATA_HELPER_WORKER_THREADS = 4;
+
+class ODataHelperProxy {
+public:
+    ODataHelperProxy(const std::string &url)
+        : m_service{ODATA_HELPER_WORKER_THREADS}
+        , m_idleWork{asio::make_work(m_service)}
+        , m_helper{std::make_shared<one::helpers::ODataHelper>(
+              std::make_shared<one::AsioExecutor>(m_service), url, "testuser",
+              "testpassword", "Sentinel-2,Sentinel-3", "products.db", ".", 10)}
+    {
+        for (int i = 0; i < ODATA_HELPER_WORKER_THREADS; i++) {
+            m_workers.push_back(std::thread([=]() { m_service.run(); }));
+        }
+    }
+    ~ODataHelperProxy()
+    {
+        m_service.stop();
+        for (auto &worker : m_workers) {
+            worker.join();
+        }
+    }
+
+    void open(std::string fileId, int flags)
+    {
+        ReleaseGIL guard;
+        m_helper->open(fileId, flags, {})
+            .then(
+                [&](one::helpers::FileHandlePtr handle) { handle->release(); });
+    }
+
+    std::string read(std::string fileId, int offset, int size)
+    {
+        ReleaseGIL guard;
+        return m_helper->open(fileId, O_RDONLY, {})
+            .then([&](one::helpers::FileHandlePtr handle) {
+                auto buf = handle->read(offset, size).get();
+                std::string data;
+                buf.appendToString(data);
+                return data;
+            })
+            .get();
+    }
+
+    int write(std::string fileId, std::string data, int offset)
+    {
+        ReleaseGIL guard;
+
+        return -1;
+    }
+
+    struct stat getattr(std::string fileId)
+    {
+        ReleaseGIL guard;
+        return m_helper->getattr(fileId).get();
+    }
+
+    void access(std::string fileId, int mask)
+    {
+        ReleaseGIL guard;
+        m_helper->access(fileId, mask).get();
+    }
+
+    std::vector<std::string> readdir(std::string fileId, int offset, int count)
+    {
+        ReleaseGIL guard;
+        std::vector<std::string> res;
+        const auto result = m_helper->readdir(fileId, offset, count).get();
+        for (auto &direntry : result) {
+            res.emplace_back(direntry.toStdString());
+        }
+        return res;
+    }
+
+    std::string readlink(std::string fileId)
+    {
+        ReleaseGIL guard;
+        return m_helper->readlink(fileId).get().toStdString();
+    }
+
+    void mknod(std::string fileId, mode_t mode, std::vector<Flag> flags)
+    {
+        ReleaseGIL guard;
+        m_helper->mknod(fileId, mode, FlagsSet(flags.begin(), flags.end()), 0)
+            .get();
+    }
+
+    void mkdir(std::string fileId, mode_t mode)
+    {
+        ReleaseGIL guard;
+        m_helper->mkdir(fileId, mode).get();
+    }
+
+    void unlink(std::string fileId)
+    {
+        ReleaseGIL guard;
+        m_helper->unlink(fileId).get();
+    }
+
+    void rmdir(std::string fileId)
+    {
+        ReleaseGIL guard;
+        m_helper->rmdir(fileId).get();
+    }
+
+    void symlink(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->symlink(from, to).get();
+    }
+
+    void rename(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->rename(from, to).get();
+    }
+
+    void link(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->link(from, to).get();
+    }
+
+    void chmod(std::string fileId, mode_t mode)
+    {
+        ReleaseGIL guard;
+        m_helper->chmod(fileId, mode).get();
+    }
+
+    void chown(std::string fileId, uid_t uid, gid_t gid)
+    {
+        ReleaseGIL guard;
+        m_helper->chown(fileId, uid, gid).get();
+    }
+
+    void truncate(std::string fileId, int offset)
+    {
+        ReleaseGIL guard;
+        m_helper->truncate(fileId, offset).get();
+    }
+
+    std::string getxattr(std::string fileId, std::string name)
+    {
+        ReleaseGIL guard;
+        return m_helper->getxattr(fileId, name).get().toStdString();
+    }
+
+    void setxattr(std::string fileId, std::string name, std::string value,
+        bool create, bool replace)
+    {
+        ReleaseGIL guard;
+        m_helper->setxattr(fileId, name, value, create, replace).get();
+    }
+
+    void removexattr(std::string fileId, std::string name)
+    {
+        ReleaseGIL guard;
+        m_helper->removexattr(fileId, name).get();
+    }
+
+    std::vector<std::string> listxattr(std::string fileId)
+    {
+        ReleaseGIL guard;
+        std::vector<std::string> res;
+        for (auto &xattr : m_helper->listxattr(fileId).get()) {
+            res.emplace_back(xattr.toStdString());
+        }
+        return res;
+    }
+
+    bool isReady()
+    {
+        try {
+            const auto result = m_helper->readdir("/Sentinel-2", 0, 5).get();
+            return !result.empty();
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+private:
+    asio::io_service m_service;
+    asio::executor_work<asio::io_service::executor_type> m_idleWork;
+    std::vector<std::thread> m_workers;
+    std::shared_ptr<one::helpers::ODataHelper> m_helper;
+};
+
+namespace {
+boost::shared_ptr<ODataHelperProxy> create(std::string url)
+{
+    return boost::make_shared<ODataHelperProxy>(url);
+}
+
+class CleanUp {
+public:
+    CleanUp() = default;
+    ~CleanUp() { std::remove("products.db"); }
+};
+
+CleanUp clean_up;
+
+} // namespace
+
+BOOST_PYTHON_MODULE(odata_helper)
+{
+    class_<ODataHelperProxy, boost::noncopyable>("ODataHelperProxy", no_init)
+        .def("__init__", make_constructor(create))
+        .def("open", &ODataHelperProxy::open)
+        .def("read", &ODataHelperProxy::read)
+        .def("write", &ODataHelperProxy::write)
+        .def("getattr", &ODataHelperProxy::getattr)
+        .def("readdir", &ODataHelperProxy::readdir)
+        .def("readlink", &ODataHelperProxy::readlink)
+        .def("mknod", &ODataHelperProxy::mknod)
+        .def("mkdir", &ODataHelperProxy::mkdir)
+        .def("unlink", &ODataHelperProxy::unlink)
+        .def("rmdir", &ODataHelperProxy::rmdir)
+        .def("symlink", &ODataHelperProxy::symlink)
+        .def("rename", &ODataHelperProxy::rename)
+        .def("link", &ODataHelperProxy::link)
+        .def("chmod", &ODataHelperProxy::chmod)
+        .def("chown", &ODataHelperProxy::chown)
+        .def("truncate", &ODataHelperProxy::truncate)
+        .def("getxattr", &ODataHelperProxy::getxattr)
+        .def("setxattr", &ODataHelperProxy::setxattr)
+        .def("removexattr", &ODataHelperProxy::removexattr)
+        .def("listxattr", &ODataHelperProxy::listxattr)
+        .def("access", &ODataHelperProxy::access)
+        .def("isReady", &ODataHelperProxy::isReady);
+}

--- a/test/integration/odata_helper_test/odata_helper_test.py
+++ b/test/integration/odata_helper_test/odata_helper_test.py
@@ -1,0 +1,87 @@
+"""This module tests ODATA helper."""
+
+__author__ = "Jakub Valenta"
+__copyright__ = """(C) 2017 Cesnet z.s.p.o,
+This software is released under the MIT license cited in 'LICENSE.txt'."""
+
+import os
+import sys
+import subprocess
+import time
+from os.path import expanduser
+
+import pytest
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.dirname(script_dir))
+# noinspection PyUnresolvedReferences
+from test_common import *
+# noinspection PyUnresolvedReferences
+from environment import common, docker
+from odata_helper import ODataHelperProxy
+from posix_test_types import *
+
+@pytest.fixture(scope='module')
+def server(request):
+    class Server(object):
+        def __init__(self, url):
+            self.url = url
+    container = docker.run(image="jakubvalenta27/dhus",
+            hostname="dhus-test",
+            name="dhus-test",
+            detach=True)
+    settings = docker.inspect(container)
+    ip = settings['NetworkSettings']['IPAddress']
+
+    def fin():
+        docker.remove([container], force=True, volumes=True)
+
+    request.addfinalizer(fin)
+    
+    return Server(("http://" + ip + ":8081").encode('ascii'))
+
+@pytest.fixture
+def helper(server):
+    proxy = ODataHelperProxy(server.url)
+    while not proxy.isReady():
+        time.sleep(1);
+    return proxy
+
+def test_readdir(helper):
+    try:
+        files = helper.readdir('/Sentinel-2', 0,  5)
+    except:
+       assert False
+    assert 3 == len(files)
+
+def test_getattr(helper):
+    try:
+        attr = helper.getattr('/Sentinel-2')
+    except:
+        assert False
+    assert 0777&(attr.st_mode) == 0555
+    assert attr.st_size == 0
+
+def test_access(helper):
+    try:
+        helper.access('/Sentinel-2', 0)
+    except:
+        assert False
+    with pytest.raises(RuntimeError) as excinfo:
+            helper.access("invalid", 0)
+    assert 'No such file' in str(excinfo.value)
+
+def test_open(helper):
+    try:
+        helper.open('/Sentinel-2/2018-03-21/S2B_MSIL1C_20180321T103019_N0206_R108_T30PUU_20180321T123706/manifest.safe', 0)
+        assert True
+    except:
+        assert False
+
+def test_readfile(helper):
+    try:
+        data = helper.read('/Sentinel-2/2018-03-21/S2B_MSIL1C_20180321T103019_N0206_R108_T30PUU_20180321T123706/manifest.safe', 0, 100000)
+    except:
+        assert False
+    assert 57985 == len(data)
+


### PR DESCRIPTION

Helper provides read only filesystem. Metadata are locally cached in
embedded Berkeley DB.

There are additional dependencies introduced by new helper. Updated onedata/builder image is available in [docker hub](https://hub.docker.com/r/jakubvalenta27/onedatabuilder/) and Dockerfile is in [github repository](https://github.com/jakub-valenta/docker-images/tree/master/onedata-builder).

Integration tests require docker image [jakubvalenta27/dhus](https://hub.docker.com/r/jakubvalenta27/dhus/). Dockerfile is also provided in [github repository](https://github.com/jakub-valenta/docker-images/tree/master/dhus).

