### PR TITLE
Implemented helper accesing Copernicus Open Access Hub through OData and SORL APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ option(WITH_SWIFT "Include Swift direct IO support" ON)
 option(WITH_GLUSTERFS "Include GlusterFS direct IO support" ON)
 option(WITH_WEBDAV "Include WebDAV direct IO support" ON)
 option(BUILD_PROXY_IO "Build Proxy IO helper." ON)
+option(WITH_DHUSODATA "Include Copernicus Data Hub support" ON)
 
 # CMake config
 set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY True)
@@ -152,6 +153,13 @@ else(WITH_WEBDAV)
     add_definitions(-DWITH_WEBDAV=0)
 endif(WITH_WEBDAV)
 
+# Copernicus Data hub support
+if(WITH_DHUSODATA)
+    find_package(odata REQUIRED)
+    set(DHUSODATA_LIBRARIES ${ODATA_LIBRARIES})
+else(WITH_DHUSODATA)
+    add_definitions(-DWITH_DHUSODATA=0)
+endif(WITH_DHUSODATA)
 
 # Setup compile flags
 set(PLATFORM_EXTRA_LIBS
@@ -228,6 +236,10 @@ endif(WITH_GLUSTERFS)
 if(WITH_WEBDAV)
     list(APPEND HELPERS_LIBRARIES ${PROXYGEN_LIBRARY})
 endif(WITH_WEBDAV)
+
+if(WITH_DHUSODATA)
+    list(APPEND HELPERS_LIBRARIES ${DHUSODATA_LIBRARIES})
+endif(WITH_DHUSODATA)
 
 add_library(helpersShared SHARED ${HELPERS_SOURCES})
 target_link_libraries(helpersShared PUBLIC ${HELPERS_LIBRARIES})

--- a/include/helpers/storageHelperCreator.h
+++ b/include/helpers/storageHelperCreator.h
@@ -59,6 +59,10 @@ constexpr auto GLUSTERFS_HELPER_NAME = "glusterfs";
 constexpr auto WEBDAV_HELPER_NAME = "webdav";
 #endif
 
+#if WITH_DHUSODATA
+constexpr auto DHUSODATA_HELPER_NAME = "dhusodata";
+#endif
+
 namespace buffering {
 
 class BufferAgentsMemoryLimitGuard;
@@ -152,6 +156,9 @@ public:
 #if WITH_WEBDAV
         std::shared_ptr<folly::IOExecutor> webDAVExecutor,
 #endif
+#if WITH_DHUSODATA
+        asio::io_service &dhusodataService,
+#endif
         asio::io_service &nullDeviceService,
         communication::Communicator &m_communicator,
         std::size_t bufferSchedulerWorkers = 1,
@@ -173,6 +180,9 @@ public:
 #endif
 #if WITH_WEBDAV
         std::shared_ptr<folly::IOExecutor> webDAVExecutor,
+#endif
+#if WITH_DHUSODATA
+        asio::io_service &dhusodataService,
 #endif
         asio::io_service &nullDeviceService,
         std::size_t bufferSchedulerWorkers = 1,
@@ -218,6 +228,9 @@ private:
 #endif
 #if WITH_WEBDAV
     std::shared_ptr<folly::IOExecutor> m_webDAVExecutor;
+#endif
+#if WITH_DHUSODATA
+    asio::io_service &m_dhusodataService,
 #endif
 
     asio::io_service &m_nullDeviceService;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,10 @@ if(NOT WITH_GLUSTERFS)
     list(REMOVE_ITEM HELPER_SOURCES  ${CMAKE_CURRENT_SOURCE_DIR}/glusterfsHelper.cc)
 endif(NOT WITH_GLUSTERFS)
 
+if(NOT WITH_DHUSODATA)
+    list(REMOVE_ITEM HELPER_SOURCES  ${CMAKE_CURRENT_SOURCE_DIR}/dhusodataHelper.cc)
+endif(NOT WITH_DHUSODATA)
+
 add_library(helpers OBJECT ${HELPER_SOURCES})
 add_dependencies(helpers clproto)
 target_include_directories(helpers SYSTEM PRIVATE

--- a/src/dhusodataHelper.cc
+++ b/src/dhusodataHelper.cc
@@ -1,0 +1,197 @@
+/*
+ * dhusodataHelper.cpp
+ *
+ *  Created on: 5. 2. 2018
+ *      Author: Jakub Valenta
+ */
+
+#include "dhusodataHelper.h"
+#include "asioExecutor.h"
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem/path.hpp>
+#include <folly/FBString.h>
+#include <folly/io/IOBufQueue.h>
+#include <memory>
+#include <odata/DataHub.h>
+#include <odata/DataHubConnection.h>
+#include <odata/FileSystemNode.h>
+#include <unistd.h>
+
+namespace one {
+namespace helpers {
+
+namespace {
+std::vector<std::string> parseMissions(const std::string &missions)
+{
+    std::vector<std::string> splited;
+    boost::split(splited, missions, [](char c) { return c == ','; });
+    return splited;
+}
+}
+
+DHUSODataFile::DHUSODataFile(folly::fbstring fileId,
+    std::shared_ptr<folly::Executor> executor,
+    std::shared_ptr<OData::DataHub> data_hub)
+    : FileHandle(std::move(fileId))
+    , m_executor(std::move(executor))
+    , m_data_hub(std::move(data_hub))
+    , m_timeout(ASYNC_OPS_TIMEOUT)
+{
+}
+
+folly::Future<folly::IOBufQueue> DHUSODataFile::read(
+    const off_t offset, const std::size_t size)
+{
+    return folly::via(m_executor.get(), [=]() {
+        folly::IOBufQueue buffer;
+        const auto content = m_data_hub->getFile(
+            boost::filesystem::path(m_fileId.c_str()), offset, size);
+        buffer.append(content.data(), content.size());
+        return folly::makeFuture(std::move(buffer));
+    });
+}
+
+folly::Future<std::size_t> DHUSODataFile::write(
+    const off_t offset, folly::IOBufQueue buf)
+{
+    return folly::via(m_executor.get(), []() {
+        return folly::makeFuture<std::size_t>(std::system_error{
+            std::make_error_code(std::errc::function_not_supported)});
+    });
+}
+
+const Timeout &DHUSODataFile::timeout() { return m_timeout; }
+
+DHUSODataHelper::DHUSODataHelper(std::shared_ptr<folly::Executor> executor,
+    const folly::fbstring &data_hub_url, const folly::fbstring &username,
+    const folly::fbstring &password, const folly::fbstring &missions,
+    const folly::fbstring &db_path, const folly::fbstring &tmp_path,
+    const std::uint32_t tmp_size)
+    : m_executor(std::move(executor))
+    , m_timeout(ASYNC_OPS_TIMEOUT)
+    , m_connection(
+          std::make_shared<OData::DataHubConnection>(data_hub_url.toStdString(),
+              username.toStdString(), password.toStdString()))
+    , m_data_hub(std::make_shared<OData::DataHub>(*m_connection,
+          parseMissions(missions.toStdString()), db_path.toStdString(),
+          tmp_path.toStdString(), tmp_size))
+{
+}
+
+folly::Future<struct stat> DHUSODataHelper::getattr(
+    const folly::fbstring &fileId)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<struct stat>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        struct stat attr;
+        std::memset(&attr, 0, sizeof(attr));
+        attr.st_uid = getuid();
+        attr.st_gid = getgid();
+        if (file->isDirectory()) {
+            attr.st_mode = 0555;
+        }
+        else {
+            attr.st_mode = 0444;
+        }
+        attr.st_size = file->getSize();
+
+        return folly::makeFuture<struct stat>(std::move(attr));
+    });
+}
+
+folly::Future<folly::Unit> DHUSODataHelper::access(
+    const folly::fbstring &fileId, const int mask)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<folly::Unit>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        return folly::makeFuture();
+    });
+}
+
+folly::Future<folly::fbvector<folly::fbstring>> DHUSODataHelper::readdir(
+    const folly::fbstring &fileId, const off_t offset, const std::size_t count)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto directory = m_data_hub->getFile(fileId.toStdString());
+        if (directory == nullptr) {
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::system_error{std::make_error_code(
+                    std::errc::no_such_file_or_directory)});
+        }
+        else if (directory->isDirectory()) {
+            auto dir_content = directory->readDir();
+            dir_content.push_back(".");
+            dir_content.push_back("..");
+            folly::fbvector<folly::fbstring> dir;
+            for (auto i = static_cast<std::size_t>(offset);
+                 i < dir_content.size() && i < offset + count; ++i) {
+                dir.push_back(folly::fbstring(dir_content[i]));
+            }
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::move(dir));
+        }
+        else {
+            return folly::makeFuture<folly::fbvector<folly::fbstring>>(
+                std::system_error{
+                    std::make_error_code(std::errc::not_a_directory)});
+        }
+    });
+}
+
+folly::Future<FileHandlePtr> DHUSODataHelper::open(
+    const folly::fbstring &fileId, const int flags, const Params &openParams)
+{
+    return folly::via(m_executor.get(), [=]() {
+        const auto file = m_data_hub->getFile(fileId.toStdString());
+        if (file == nullptr) {
+            return folly::makeFuture<FileHandlePtr>(std::system_error{
+                std::make_error_code(std::errc::no_such_file_or_directory)});
+        }
+        else if (file->isDirectory()) {
+            return folly::makeFuture<FileHandlePtr>(std::system_error{
+                std::make_error_code(std::errc::is_a_directory)});
+        }
+        return folly::makeFuture<FileHandlePtr>(
+            std::make_shared<DHUSODataFile>(fileId, m_executor, m_data_hub));
+    });
+}
+
+folly::Future<folly::fbstring> DHUSODataHelper::getxattr(
+    const folly::fbstring &uuid, const folly::fbstring &name)
+{
+    return folly::via(m_executor.get(),
+        []() { return makeFuturePosixException<folly::fbstring>(ENOTSUP); });
+}
+
+const Timeout &DHUSODataHelper::timeout() { return m_timeout; }
+
+DHUSODataHelperFactory::DHUSODataHelperFactory(asio::io_service &service)
+    : m_service(service)
+{
+}
+
+std::shared_ptr<StorageHelper> DHUSODataHelperFactory::createStorageHelper(
+    const Params &parameters)
+{
+    const auto &url = getParam(parameters, "datahubUrl");
+    const auto &username = getParam(parameters, "username");
+    const auto &password = getParam(parameters, "password");
+    const auto &missions = getParam(parameters, "missions");
+    const auto &db_path = getParam(parameters, "databasePath");
+    const auto &tmp_path = getParam(parameters, "tmpPath");
+    const auto &tmp_size = getParam(parameters, "tmpSize");
+    return std::make_shared<DHUSODataHelper>(
+        std::make_shared<AsioExecutor>(m_service), url, username, password,
+        missions, db_path, tmp_path, std::stoi(tmp_size.toStdString()));
+}
+
+} /* namespace helpers */
+} /* namespace one */

--- a/src/dhusodataHelper.h
+++ b/src/dhusodataHelper.h
@@ -1,0 +1,84 @@
+/*
+ * dhusodataHelper.h
+ *
+ *  Created on: 5. 2. 2018
+ *      Author: Jakub Valenta
+ */
+
+#ifndef HELPERS_DHUSODATAHELPER_H_
+#define HELPERS_DHUSODATAHELPER_H_
+
+#include "helpers/storageHelper.h"
+
+namespace OData {
+
+class Connection;
+class DataHub;
+class FileSystemNode;
+}
+
+namespace one {
+namespace helpers {
+
+class DHUSODataFile : public FileHandle {
+public:
+    DHUSODataFile(folly::fbstring fileId,
+        std::shared_ptr<folly::Executor> executor,
+        std::shared_ptr<OData::DataHub> data_hub);
+    virtual ~DHUSODataFile() = default;
+    folly::Future<folly::IOBufQueue> read(
+        const off_t offset, const std::size_t size) override;
+
+    folly::Future<std::size_t> write(
+        const off_t offset, folly::IOBufQueue buf) override;
+    const Timeout &timeout() override;
+
+private:
+    std::shared_ptr<folly::Executor> m_executor;
+    std::shared_ptr<OData::DataHub> m_data_hub;
+    Timeout m_timeout;
+};
+
+class DHUSODataHelper : public StorageHelper {
+public:
+    explicit DHUSODataHelper(std::shared_ptr<folly::Executor> executor,
+        const folly::fbstring &data_hub_url, const folly::fbstring &username,
+        const folly::fbstring &password, const folly::fbstring &missions,
+        const folly::fbstring &db_path, const folly::fbstring &tmp_path,
+        const std::uint32_t tmp_size);
+    virtual ~DHUSODataHelper() = default;
+    folly::Future<struct stat> getattr(const folly::fbstring &fileId) override;
+    folly::Future<folly::Unit> access(
+        const folly::fbstring &fileId, const int mask) override;
+    folly::Future<folly::fbvector<folly::fbstring>> readdir(
+        const folly::fbstring &fileId, const off_t offset,
+        const std::size_t count) override;
+    folly::Future<FileHandlePtr> open(const folly::fbstring &fileId,
+        const int flags, const Params &openParams) override;
+    folly::Future<folly::fbstring> getxattr(
+        const folly::fbstring &uuid, const folly::fbstring &name) override;
+
+    const Timeout &timeout() override;
+
+private:
+    std::shared_ptr<folly::Executor> m_executor;
+    Timeout m_timeout;
+    std::shared_ptr<OData::Connection> m_connection;
+    std::shared_ptr<OData::DataHub> m_data_hub;
+};
+
+class DHUSODataHelperFactory : public StorageHelperFactory {
+public:
+    DHUSODataHelperFactory(asio::io_service &service);
+    virtual ~DHUSODataHelperFactory() = default;
+    std::shared_ptr<StorageHelper> createStorageHelper(
+        const Params &parameters) override;
+
+private:
+    asio::io_service &m_service;
+};
+
+} /* namespace helpers */
+} /* namespace one */
+
+#endif /* HELPERS_DHUSODATAHELPER_H_ */

--- a/src/storageHelperCreator.cc
+++ b/src/storageHelperCreator.cc
@@ -36,6 +36,9 @@
 #include "webDAVHelper.h"
 #include <folly/executors/IOExecutor.h>
 #endif
+#if WITH_DHUSODATA
+#include "dhusodataHelper.h"
+#endif
 
 namespace one {
 namespace helpers {
@@ -58,6 +61,9 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_WEBDAV
     std::shared_ptr<folly::IOExecutor> webDAVExecutor,
+#endif
+#if WITH_DHUSODATA
+    asio::io_service &dhusodataService,
 #endif
     asio::io_service &nullDeviceService,
     communication::Communicator &communicator,
@@ -84,6 +90,10 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_WEBDAV
     m_webDAVExecutor{std::move(webDAVExecutor)}
+    ,
+#endif
+#if WITH_DHUSODATA
+    m_dhusodataService(dhusodataService)
     ,
 #endif
     m_nullDeviceService{nullDeviceService}
@@ -113,6 +123,9 @@ StorageHelperCreator::StorageHelperCreator(
 #if WITH_WEBDAV
     std::shared_ptr<folly::IOExecutor> webDAVExecutor,
 #endif
+#if WITH_DHUSODATA
+    asio::io_service &dhusodataService,
+#endif
     asio::io_service &nullDeviceService, std::size_t bufferSchedulerWorkers,
     buffering::BufferLimits bufferLimits)
     :
@@ -137,6 +150,10 @@ StorageHelperCreator::StorageHelperCreator(
 #endif
 #if WITH_WEBDAV
     m_webDAVExecutor{std::move(webDAVExecutor)}
+    ,
+#endif
+#if WITH_DHUSODATA
+    m_dhusodataService(dhusodataService)
     ,
 #endif
     m_nullDeviceService{nullDeviceService}
@@ -197,6 +214,11 @@ std::shared_ptr<StorageHelper> StorageHelperCreator::getStorageHelper(
     if (name == WEBDAV_HELPER_NAME)
         helper =
             WebDAVHelperFactory{m_webDAVExecutor}.createStorageHelper(args);
+#endif
+#if WITH_DHUSODATA
+    if (name == DHUSODATA_HELPER_NAME)
+        helper = DHUSODataHelperFactory{m_dhusodataService}.createStorageHelper(
+            args);
 #endif
 
     if (name == NULL_DEVICE_HELPER_NAME)

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -60,6 +60,10 @@ if(NOT WITH_GLUSTERFS)
     list(REMOVE_ITEM TEST_DIRS  glusterfs_helper_test)
 endif(NOT WITH_GLUSTERFS)
 
+if(NOT WITH_DHUSODATA)
+    list(REMOVE_ITEM TEST_DIRS  dhusodata_helper_test)
+endif(NOT WITH_DHUSODATA)
+
 foreach(TEST_DIR ${TEST_DIRS})
     string(REGEX REPLACE "(.*)_test" "\\1" TEST_NAME ${TEST_DIR})
     file(COPY ${TEST_DIR} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/test/integration/dhusodata_helper_test/dhusodataHelperProxy.cc
+++ b/test/integration/dhusodata_helper_test/dhusodataHelperProxy.cc
@@ -1,0 +1,268 @@
+/*
+ * dhusodataHelperProxy.cc
+ *
+ *  Created on: 11. 4. 2018
+ *      Author: jakub
+ */
+#include "dhusodataHelper.h"
+
+#include "asioExecutor.h"
+#include <asio/buffer.hpp>
+#include <asio/io_service.hpp>
+#include <boost/make_shared.hpp>
+#include <boost/python.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/raw_function.hpp>
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+using namespace boost::python;
+using namespace one::helpers;
+
+class ReleaseGIL {
+public:
+    ReleaseGIL()
+        : threadState{PyEval_SaveThread(), PyEval_RestoreThread}
+    {
+    }
+
+private:
+    std::unique_ptr<PyThreadState, decltype(&PyEval_RestoreThread)> threadState;
+};
+
+constexpr int DHUS_ODATA_HELPER_WORKER_THREADS = 4;
+
+class DHUSODataHelperProxy {
+public:
+    DHUSODataHelperProxy(const std::string &url)
+        : m_service{DHUS_ODATA_HELPER_WORKER_THREADS}
+        , m_idleWork{asio::make_work_guard(m_service)}
+        , m_helper{std::make_shared<one::helpers::DHUSODataHelper>(
+              std::make_shared<one::AsioExecutor>(m_service), url, "testuser",
+              "testpassword", "Sentinel-2,Sentinel-3", "products.db", ".", 10)}
+    {
+        for (int i = 0; i < DHUS_ODATA_HELPER_WORKER_THREADS; i++) {
+            m_workers.push_back(std::thread([=]() { m_service.run(); }));
+        }
+    }
+    ~DHUSODataHelperProxy()
+    {
+        m_service.stop();
+        for (auto &worker : m_workers) {
+            worker.join();
+        }
+    }
+
+    void open(std::string fileId, int flags)
+    {
+        ReleaseGIL guard;
+        m_helper->open(fileId, flags, {})
+            .then(
+                [&](one::helpers::FileHandlePtr handle) { handle->release(); });
+    }
+
+    std::string read(std::string fileId, int offset, int size)
+    {
+        ReleaseGIL guard;
+        return m_helper->open(fileId, O_RDONLY, {})
+            .then([&](one::helpers::FileHandlePtr handle) {
+                auto buf = handle->read(offset, size).get();
+                std::string data;
+                buf.appendToString(data);
+                return data;
+            })
+            .get();
+    }
+
+    int write(std::string fileId, std::string data, int offset)
+    {
+        ReleaseGIL guard;
+
+        return -1;
+    }
+
+    struct stat getattr(std::string fileId)
+    {
+        ReleaseGIL guard;
+        return m_helper->getattr(fileId).get();
+    }
+
+    void access(std::string fileId, int mask)
+    {
+        ReleaseGIL guard;
+        m_helper->access(fileId, mask).get();
+    }
+
+    std::vector<std::string> readdir(std::string fileId, int offset, int count)
+    {
+        ReleaseGIL guard;
+        std::vector<std::string> res;
+        const auto result = m_helper->readdir(fileId, offset, count).get();
+        for (auto &direntry : result) {
+            res.emplace_back(direntry.toStdString());
+        }
+        return res;
+    }
+
+    std::string readlink(std::string fileId)
+    {
+        ReleaseGIL guard;
+        return m_helper->readlink(fileId).get().toStdString();
+    }
+
+    void mknod(std::string fileId, mode_t mode, std::vector<Flag> flags)
+    {
+        ReleaseGIL guard;
+        m_helper->mknod(fileId, mode, FlagsSet(flags.begin(), flags.end()), 0)
+            .get();
+    }
+
+    void mkdir(std::string fileId, mode_t mode)
+    {
+        ReleaseGIL guard;
+        m_helper->mkdir(fileId, mode).get();
+    }
+
+    void unlink(std::string fileId, int size)
+    {
+        ReleaseGIL guard;
+        m_helper->unlink(fileId, size).get();
+    }
+
+    void rmdir(std::string fileId)
+    {
+        ReleaseGIL guard;
+        m_helper->rmdir(fileId).get();
+    }
+
+    void symlink(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->symlink(from, to).get();
+    }
+
+    void rename(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->rename(from, to).get();
+    }
+
+    void link(std::string from, std::string to)
+    {
+        ReleaseGIL guard;
+        m_helper->link(from, to).get();
+    }
+
+    void chmod(std::string fileId, mode_t mode)
+    {
+        ReleaseGIL guard;
+        m_helper->chmod(fileId, mode).get();
+    }
+
+    void chown(std::string fileId, uid_t uid, gid_t gid)
+    {
+        ReleaseGIL guard;
+        m_helper->chown(fileId, uid, gid).get();
+    }
+
+    void truncate(
+        std::string fileId, const off_t size, const size_t currentSize)
+    {
+        ReleaseGIL guard;
+        m_helper->truncate(fileId, size, currentSize).get();
+    }
+
+    std::string getxattr(std::string fileId, std::string name)
+    {
+        ReleaseGIL guard;
+        return m_helper->getxattr(fileId, name).get().toStdString();
+    }
+
+    void setxattr(std::string fileId, std::string name, std::string value,
+        bool create, bool replace)
+    {
+        ReleaseGIL guard;
+        m_helper->setxattr(fileId, name, value, create, replace).get();
+    }
+
+    void removexattr(std::string fileId, std::string name)
+    {
+        ReleaseGIL guard;
+        m_helper->removexattr(fileId, name).get();
+    }
+
+    std::vector<std::string> listxattr(std::string fileId)
+    {
+        ReleaseGIL guard;
+        std::vector<std::string> res;
+        for (auto &xattr : m_helper->listxattr(fileId).get()) {
+            res.emplace_back(xattr.toStdString());
+        }
+        return res;
+    }
+
+    bool isReady()
+    {
+        try {
+            const auto result = m_helper->readdir("/Sentinel-2", 0, 5).get();
+            return !result.empty();
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+private:
+    asio::io_service m_service;
+    asio::executor_work_guard<asio::io_service::executor_type> m_idleWork;
+    std::vector<std::thread> m_workers;
+    std::shared_ptr<one::helpers::DHUSODataHelper> m_helper;
+};
+
+namespace {
+boost::shared_ptr<DHUSODataHelperProxy> create(std::string url)
+{
+    return boost::make_shared<DHUSODataHelperProxy>(url);
+}
+
+class CleanUp {
+public:
+    CleanUp() = default;
+    ~CleanUp() { std::remove("products.db"); }
+};
+
+CleanUp clean_up;
+
+} // namespace
+
+BOOST_PYTHON_MODULE(dhusodata_helper)
+{
+    class_<DHUSODataHelperProxy, boost::noncopyable>(
+        "DHUSODataHelperProxy", no_init)
+        .def("__init__", make_constructor(create))
+        .def("open", &DHUSODataHelperProxy::open)
+        .def("read", &DHUSODataHelperProxy::read)
+        .def("write", &DHUSODataHelperProxy::write)
+        .def("getattr", &DHUSODataHelperProxy::getattr)
+        .def("readdir", &DHUSODataHelperProxy::readdir)
+        .def("readlink", &DHUSODataHelperProxy::readlink)
+        .def("mknod", &DHUSODataHelperProxy::mknod)
+        .def("mkdir", &DHUSODataHelperProxy::mkdir)
+        .def("unlink", &DHUSODataHelperProxy::unlink)
+        .def("rmdir", &DHUSODataHelperProxy::rmdir)
+        .def("symlink", &DHUSODataHelperProxy::symlink)
+        .def("rename", &DHUSODataHelperProxy::rename)
+        .def("link", &DHUSODataHelperProxy::link)
+        .def("chmod", &DHUSODataHelperProxy::chmod)
+        .def("chown", &DHUSODataHelperProxy::chown)
+        .def("truncate", &DHUSODataHelperProxy::truncate)
+        .def("getxattr", &DHUSODataHelperProxy::getxattr)
+        .def("setxattr", &DHUSODataHelperProxy::setxattr)
+        .def("removexattr", &DHUSODataHelperProxy::removexattr)
+        .def("listxattr", &DHUSODataHelperProxy::listxattr)
+        .def("access", &DHUSODataHelperProxy::access)
+        .def("isReady", &DHUSODataHelperProxy::isReady);
+}

--- a/test/integration/dhusodata_helper_test/dhusodata_helper_test.py
+++ b/test/integration/dhusodata_helper_test/dhusodata_helper_test.py
@@ -1,0 +1,87 @@
+"""This module tests DHUSODATA helper."""
+
+__author__ = "Jakub Valenta"
+__copyright__ = """(C) 2017 Cesnet z.s.p.o,
+This software is released under the MIT license cited in 'LICENSE.txt'."""
+
+import os
+import sys
+import subprocess
+import time
+from os.path import expanduser
+
+import pytest
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
+sys.path.insert(0, os.path.dirname(script_dir))
+# noinspection PyUnresolvedReferences
+from test_common import *
+# noinspection PyUnresolvedReferences
+from environment import common, docker
+from dhusodata_helper import DHUSODataHelperProxy
+from posix_test_types import *
+
+@pytest.fixture(scope='module')
+def server(request):
+    class Server(object):
+        def __init__(self, url):
+            self.url = url
+    container = docker.run(image="jakubvalenta27/dhus",
+            hostname="dhus-test",
+            name="dhus-test",
+            detach=True)
+    settings = docker.inspect(container)
+    ip = settings['NetworkSettings']['IPAddress']
+
+    def fin():
+        docker.remove([container], force=True, volumes=True)
+
+    request.addfinalizer(fin)
+    
+    return Server(("http://" + ip + ":8081").encode('ascii'))
+
+@pytest.fixture
+def helper(server):
+    proxy = DHUSODataHelperProxy(server.url)
+    while not proxy.isReady():
+        time.sleep(1);
+    return proxy
+
+def test_readdir(helper):
+    try:
+        files = helper.readdir('/Sentinel-2', 0,  5)
+    except:
+       assert False
+    assert 3 == len(files)
+
+def test_getattr(helper):
+    try:
+        attr = helper.getattr('/Sentinel-2')
+    except:
+        assert False
+    assert 0777&(attr.st_mode) == 0555
+    assert attr.st_size == 0
+
+def test_access(helper):
+    try:
+        helper.access('/Sentinel-2', 0)
+    except:
+        assert False
+    with pytest.raises(RuntimeError) as excinfo:
+            helper.access("invalid", 0)
+    assert 'No such file' in str(excinfo.value)
+
+def test_open(helper):
+    try:
+        helper.open('/Sentinel-2/2018-03-21/S2B_MSIL1C_20180321T103019_N0206_R108_T30PUU_20180321T123706/manifest.safe', 0)
+        assert True
+    except:
+        assert False
+
+def test_readfile(helper):
+    try:
+        data = helper.read('/Sentinel-2/2018-03-21/S2B_MSIL1C_20180321T103019_N0206_R108_T30PUU_20180321T123706/manifest.safe', 0, 100000)
+    except:
+        assert False
+    assert 57985 == len(data)
+


### PR DESCRIPTION
Helper provides read only filesystem. Metadata are locally cached in
embedded Berkeley DB.

There are additional dependencies introduced by new helper. Updated onedata/builder image is available in docker hub and Dockerfile is in github repository.

Integration tests require docker image jakubvalenta27/dhus. Dockerfile is also provided in github repository.